### PR TITLE
remove process env in client

### DIFF
--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { EXPO_PUBLIC_API_URL } from "@env";
 
-const API_BASE_URL =
-  process.env.EXPO_PUBLIC_API_URL || "http://localhost:5000/api/v1";
+const API_BASE_URL = EXPO_PUBLIC_API_URL || "http://localhost:5000/api/v1";
 
 
 

--- a/client/types/env.d.ts
+++ b/client/types/env.d.ts
@@ -2,6 +2,6 @@ declare module '@env' {
   export const GOOGLE_WEB_ID: string;
   export const GOOGLE_IOS_ID: string;
   export const GOOGLE_PLACES_API: string;
-
+  export const EXPO_PUBLIC_API_URL: string;
   // other ones
 }

--- a/server/test/express.mock.ts
+++ b/server/test/express.mock.ts
@@ -1,43 +1,65 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { jest } from '@jest/globals';
-import { ResolveFnOutput } from 'module';
 
 /**
  * Creates a mock Express Request object
  */
 export const mockRequest = (): Partial<Request> => {
-    const req: Partial<Request> = {};
-    req.body = {};
-    req.params = {};
-    req.query = {};
-    req.headers = {};
-    return req;
+  const req: Partial<Request> = {};
+  req.body = {};
+  req.params = {};
+  req.query = {};
+  req.headers = {
+    authorization: undefined
   };
+  req.userId = undefined; // For custom auth middleware
+  return req;
+};
+
+/**
+ * Creates a mock Express Response object with Jest spy functions
+ */
+export const mockResponse = () => {
+  const res: any = {};
   
-  /**
-   * Creates a mock Express Response object with Jest spy functions
-   */
- export const mockResponse = (): Partial<Response> => {
-    const res: Partial<Response> = {};
-    // Create properly typed mock functions
-    // Status method
-    // Status method
-  res.status = jest.fn().mockImplementation((code: number) => res as Response);
+  // Mock all the response methods with appropriate parameter types
+  res.status = jest.fn((code: number) => res);
+  res.json = jest.fn((data: any) => res);
+  res.send = jest.fn((body: any) => res);
+  res.sendStatus = jest.fn((code: number) => res);
+  res.setHeader = jest.fn((name: string, value: string) => res);
+  res.cookie = jest.fn((name: string, value: string, options?: any) => res);
+  res.clearCookie = jest.fn((name: string, options?: any) => res);
+  res.redirect = jest.fn((url: string) => res);
+  res.render = jest.fn((view: string, locals?: any) => res);
+  res.end = jest.fn(() => res);
   
-  // JSON method
-  res.json = jest.fn().mockReturnThis();
-  
-  // Send method
-  res.send = jest.fn().mockReturnThis();
-  
-  // Additional common methods
-  res.sendStatus = jest.fn().mockReturnThis();
-  res.setHeader = jest.fn().mockReturnThis();
-  res.cookie = jest.fn().mockReturnThis();
-  res.clearCookie = jest.fn().mockReturnThis();
-  res.redirect = jest.fn().mockReturnThis();
-  res.render = jest.fn().mockReturnThis();
-  res.end = jest.fn().mockReturnThis();
-    
-    return res as Response;
+  return res as Partial<Response>;
+};
+
+/**
+ * Creates a mock Express NextFunction
+ */
+export const mockNext = (): NextFunction => {
+  return jest.fn();
+};
+
+/**
+ * Helper to create a complete set of Express mocks
+ */
+export const mockExpressItems = () => {
+  return {
+    req: mockRequest(),
+    res: mockResponse(),
+    next: mockNext()
   };
+};
+
+// Declare module augmentation for Express Request
+declare global {
+  namespace Express {
+    interface Request {
+      userId?: string;
+    }
+  }
+}

--- a/server/test/services/auth.test.ts
+++ b/server/test/services/auth.test.ts
@@ -489,8 +489,7 @@ describe("AuthService", () => {
       (crypto.createHash as jest.Mock).mockReturnValueOnce(mockHash);
 
       // Mock Date.now
-      const originalDateNow = Date.now;
-      (Date.now as jest.Mock).mockReturnValueOnce(1000);
+      jest.spyOn(Date, 'now').mockImplementation(() => 1616161616161);
 
       // Mock sendEmail
       (sendEmail as jest.Mock).mockResolvedValueOnce(undefined as never);
@@ -511,9 +510,6 @@ describe("AuthService", () => {
         subject: "Password Reset Request",
       }));
       expect(result).toEqual({ message: "Password reset email sent" });
-
-      // Restore Date.now
-      Date.now = originalDateNow;
     });
 
     it("should throw NotFoundError if user not found", async () => {


### PR DESCRIPTION
Issue when caching the api request url for the metro bundler.

turns out to be a problem with how env was being called

Also continue to work on fixes for backend jest test